### PR TITLE
Force use python3 for trace2html

### DIFF
--- a/.github/workflows/build_bromite_dev.yaml
+++ b/.github/workflows/build_bromite_dev.yaml
@@ -242,7 +242,7 @@ jobs:
         run: |
           cd $WORKSPACE
           $WORKSPACE/ninjatracing/ninjatracing $WORKSPACE/chromium/src/out/bromite/.ninja_log >$WORKSPACE/chromium/src/out/bromite/ninja_log_trace.json
-          $WORKSPACE/chromium/src/third_party/catapult/tracing/bin/trace2html $WORKSPACE/chromium/src/out/bromite/ninja_log_trace.json
+          python3 $WORKSPACE/chromium/src/third_party/catapult/tracing/bin/trace2html $WORKSPACE/chromium/src/out/bromite/ninja_log_trace.json
           
       - name: Build Bromite Windows
         if: ${{ github.event.inputs.target_os == 'win' || github.event.inputs.target_os == 'all' }}
@@ -270,7 +270,7 @@ jobs:
         run: |
           cd $WORKSPACE
           $WORKSPACE/ninjatracing/ninjatracing $WORKSPACE/chromium/src/out/bromite_win/.ninja_log >$WORKSPACE/chromium/src/out/bromite_win/ninja_log_trace.json
-          $WORKSPACE/chromium/src/third_party/catapult/tracing/bin/trace2html $WORKSPACE/chromium/src/out/bromite_win/ninja_log_trace.json
+          python3 $WORKSPACE/chromium/src/third_party/catapult/tracing/bin/trace2html $WORKSPACE/chromium/src/out/bromite_win/ninja_log_trace.json
 
       - name: Generate breakpad symbols
         if: ${{ github.event.inputs.target_os == 'android' || github.event.inputs.target_os == 'all' }}


### PR DESCRIPTION
see https://github.com/uazo/bromite-buildtools/actions/runs/4598386439/jobs/8126260369#step:5:11
```
Traceback (most recent call last):
  File "/home/lg/working_dir/chromium/src/third_party/catapult/tracing/bin/trace2html", line 14, in <module>
    from tracing_build import trace2html
  File "/home/lg/working_dir/chromium/src/third_party/catapult/tracing/tracing_build/trace2html.py", line 17, in <module>
    from py_vulcanize import generate
  File "/home/lg/working_dir/chromium/src/third_party/catapult/common/py_vulcanize/py_vulcanize/__init__.py", line 12, in <module>
    from py_vulcanize.project import Project
  File "/home/lg/working_dir/chromium/src/third_party/catapult/common/py_vulcanize/py_vulcanize/project.py", line 16, in <module>
    from py_vulcanize import resource_loader
  File "/home/lg/working_dir/chromium/src/third_party/catapult/common/py_vulcanize/py_vulcanize/resource_loader.py", line 16, in <module>
    from py_vulcanize import html_module
  File "/home/lg/working_dir/chromium/src/third_party/catapult/common/py_vulcanize/py_vulcanize/html_module.py", line [11](https://github.com/uazo/bromite-buildtools/actions/runs/4598386439/jobs/8126260369#step:5:12), in <module>
    from py_vulcanize import parse_html_deps
  File "/home/lg/working_dir/chromium/src/third_party/catapult/common/py_vulcanize/py_vulcanize/parse_html_deps.py", line 49, in <module>
    import bs4
  File "/home/lg/working_dir/chromium/src/third_party/catapult/third_party/beautifulsoup4-4.9.3/py3k/bs4/__init__.py", line 32, in <module>
    from .builder import builder_registry, ParserRejectedMarkup
  File "/home/lg/working_dir/chromium/src/third_party/catapult/third_party/beautifulsoup4-4.9.3/py3k/bs4/builder/__init__.py", line 7, in <module>
    from bs4.element import (
  File "/home/lg/working_dir/chromium/src/third_party/catapult/third_party/beautifulsoup4-4.9.3/py3k/bs4/element.py", line 19, in <module>
    from bs4.formatter import (
  File "/home/lg/working_dir/chromium/src/third_party/catapult/third_party/beautifulsoup4-4.9.3/py3k/bs4/formatter.py", line 1, in <module>
    from bs4.dammit import EntitySubstitution
  File "/home/lg/working_dir/chromium/src/third_party/catapult/third_party/beautifulsoup4-4.9.3/py3k/bs4/dammit.py", line [13](https://github.com/uazo/bromite-buildtools/actions/runs/4598386439/jobs/8126260369#step:5:14), in <module>
    from html.entities import codepoint2name
ImportError: No module named html.entities
```